### PR TITLE
Add loader options

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const optsMap = {
 const constructDart2JsOptions = (options) =>
   Object.keys(options).reduce((res, key) => {
     const mapping = optsMap[key];
-    return mapping ? `${res} ${mapping}` : res;
+    return (mapping === true) ? `${res} ${mapping}` : res;
   }, '');
 
 module.exports = function(source) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const colors = require('colors');
 
 module.exports = function(source) {
   const callback = this.async();
@@ -11,7 +12,15 @@ module.exports = function(source) {
   child_process.execSync(`mkdir -p '${tmp}'`);
 
   child_process.exec(cmd, (error, stdout, stderr) => {
-    if (error) { return callback(error, null); }
+    // If there was an error
+    if (error) {
+      // Output it into the console
+      const msg = stdout.red;
+      throw new Error(msg);
+
+      // Return from the function and call the callback
+      return callback(error, null);
+    }
     const out = fs.readFileSync(path.join(tmp, `${fname}.js`), 'utf8');
     callback(null, out);
   });

--- a/index.js
+++ b/index.js
@@ -2,12 +2,42 @@ const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const colors = require('colors');
+const loaderUtils = require('loader-utils');
+
+/**
+ * @summary
+ * The map between the options passed to the loader
+ * and the command-line `dart2js` utility flags.
+ */
+const optsMap = {
+  'minimize': '-m',
+  'typeCheck': '-c',
+};
+
+/**
+ * @summary
+ * Construct a command-line `dart2js` utility options string
+ * from a given loader options object.
+ *
+ * @return {string}
+ */
+const constructDart2JsOptions = (options) =>
+  Object.keys(options).reduce((res, key) => {
+    const mapping = optsMap[key];
+    return mapping ? `${res} ${mapping}` : res;
+  }, '');
 
 module.exports = function(source) {
+  // Retrieve the options that were passed to the loader
+  const options = loaderUtils.getOptions(this);
+
+  // Construct the command-line options to the `dart2js` utility
+  const dart2JsOptionsStr = constructDart2JsOptions(options);
+
   const callback = this.async();
   const tmp = path.join(__dirname, 'tmp');
   const fname = path.basename(this.resourcePath, '.dart');
-  const cmd = `dart2js -o '${path.join(tmp, `${fname}.js`)}' '${this.resourcePath}'`;
+  const cmd = `dart2js ${dart2JsOptionsStr} -o '${path.join(tmp, `${fname}.js`)}' '${this.resourcePath}'`;
   child_process.execSync(`rm -rf '${tmp}'`);
   child_process.execSync(`mkdir -p '${tmp}'`);
 

--- a/index.js
+++ b/index.js
@@ -10,10 +10,9 @@ module.exports = function(source) {
   child_process.execSync(`rm -rf '${tmp}'`);
   child_process.execSync(`mkdir -p '${tmp}'`);
 
-  child_process.exec(cmd, function(error, stdout, stderr) {
+  child_process.exec(cmd, (error, stdout, stderr) => {
     if (error) { return callback(error, null); }
     const out = fs.readFileSync(path.join(tmp, `${fname}.js`), 'utf8');
     callback(null, out);
   });
 };
-

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(source) {
     if (error) {
       // Output it into the console
       const msg = stdout.red;
-      throw new Error(msg);
+      console.error(msg);
 
       // Return from the function and call the callback
       return callback(error, null);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Matt Dziuban",
   "description": "Dart loader module for webpack",
   "dependencies": {
+    "colors": "^1.1.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "author": "Matt Dziuban",
   "description": "Dart loader module for webpack",
   "dependencies": {
-    "colors": "^1.1.2"
+    "colors": "^1.1.2",
+    "loader-utils": "^1.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the options for the loader.

The new options available are:
   - minimze
   - typeCheck

Those are converted to the `dart2js` utility command-line options directly.
The `minimize` option corresponds to the `-m` flag, whereas `typeCheck` - to `-c`.